### PR TITLE
LUT-27171: Fix error 500 when trying to unpublish blogs

### DIFF
--- a/src/java/fr/paris/lutece/plugins/blog/web/BlogPublicationJspBean.java
+++ b/src/java/fr/paris/lutece/plugins/blog/web/BlogPublicationJspBean.java
@@ -255,7 +255,7 @@ public class BlogPublicationJspBean extends BlogJspBean
     @Action( ACTION_UNPUBLISHE_DOCUMENT )
     public String doUnPublishDocument( HttpServletRequest request )
     {
-
+        _blogPublication = new BlogPublication( );
         populate( _blogPublication, request );
 
         BlogPublicationHome.remove( _blogPublication.getIdBlog( ), _blogPublication.getIdPortlet( ) );


### PR DESCRIPTION
avoid the case when _blogPublication is null
https://dev.lutece.paris.fr/bugtracker/issues/27171